### PR TITLE
疑似路径错误

### DIFF
--- a/frp/Makefile
+++ b/frp/Makefile
@@ -21,7 +21,7 @@ GO_PKG_BUILD_PKG:=github.com/fatedier/frp/cmd/...
 GO_PKG_LDFLAGS:=-s -w
 
 include $(INCLUDE_DIR)/package.mk
-include ../../lang/golang/golang-package.mk
+include ../../packages/lang/golang/golang-package.mk
 
 define Package/frp/template
   SECTION:=net


### PR DESCRIPTION
在LEDE-K3项目最新的ci分支上执行`scripts/feeds update -a`的时候出现了一个错误：
```
make[1]: *** No rule to make target '../../lang/golang/golang-package.mk'.  Stop.
```
我看好像路径有点问题，改了一下再试就没报错了。
我没学过编译，makefile也看不懂，可能说得不对，见谅。